### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,5 +3,6 @@ version=0.0.1
 author=Wojciech Szlachta <wojciech@szlachta.net>
 maintainer=Wojciech Szlachta <wojciech@szlachta.net>
 sentence=Example Arduino library using Google Test framework for testing and mocking C++ classes.
+paragraph=
 category=Other
 url=https://github.com/wjszlachta/arduino-lib-googletest-sample


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format